### PR TITLE
Made dest folder optional and removed superfluous dl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ npm link # Gives you access to `otr` in your terminal
 ## Usage
 
 ### CLI
-The CLI has only one command, `dl`. It takes two required parameters, `url` and `dir`.
+The CLI takes two parameters, `url` and `dir`. The second is optional.
 ```sh
-otr dl https://soundcloud.com/artist/track ~/Music
+otr https://soundcloud.com/artist/track ~/Music
+
+If a `dir` is not specified, the current directory will be used.
 ```
 
 ### Node

--- a/bin/otr.js
+++ b/bin/otr.js
@@ -18,7 +18,7 @@ commander
   .parse(process.argv);
 
 if (targetUrl) {
-  downloader(url, dest, process.exit);
+  downloader(targetUrl, destPath, process.exit);
 } else {
   commander.outputHelp();
 }

--- a/bin/otr.js
+++ b/bin/otr.js
@@ -4,13 +4,22 @@ var commander = require('commander');
 var pkg = require('../package.json');
 
 var downloader = require('../lib/downloader');
+var targetUrl, destPath;
 
-commander.command('dl <url> <dest>').action(function(url, dest) {
+commander
+  .arguments('<url> [dest]')
+  .action(function(url, dest) {
+    targetUrl = url;
+    destPath = dest || __dirname;
+  });
+
+commander
+  .version(pkg.version)
+  .parse(process.argv);
+
+if (targetUrl) {
   downloader(url, dest, process.exit);
-});
-
-commander.version(pkg.version).parse(process.argv);
-
-if (!process.argv.slice(2).length) {
+} else {
   commander.outputHelp();
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "off-the-rip",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Downloads audio, artwork, and metadata from Soundcloud",
   "author": "Jacob Kelley",
   "keywords": [],


### PR DESCRIPTION
I removed the `dl` command. If there's only one command, why not just make it the default behavior?

And now, if a second argument is not specified, it will just default to the current directory.
