### PR TITLE
Fix: otr fails on tracks with slash in title

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -31,9 +31,10 @@ function add_slashes(str) {
 
 function download(soundcloud_url, dest, info, callback) {
   var tmp_name = new Date().getTime();
+  var title = info.title.replace(/\//g, '')
 
   var audio_temp_dest = path.join('/tmp', 'audio-' + tmp_name + '.mp3');
-  var audio_dest = path.join(dest, info.title + '.mp3');
+  var audio_dest = path.join(dest, title + '.mp3');
   var artwork_temp_dest = path.join('/tmp', 'artwork-' + tmp_name + '.jpg');
 
   async.series([

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -31,7 +31,7 @@ function add_slashes(str) {
 
 function download(soundcloud_url, dest, info, callback) {
   var tmp_name = new Date().getTime();
-  var title = info.title.replace(/\//g, '_')
+  var title = info.title.replace(/\\\/\'\"/g, '_')
 
   var audio_temp_dest = path.join('/tmp', 'audio-' + tmp_name + '.mp3');
   var audio_dest = path.join(dest, title + '.mp3');

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -31,7 +31,7 @@ function add_slashes(str) {
 
 function download(soundcloud_url, dest, info, callback) {
   var tmp_name = new Date().getTime();
-  var title = info.title.replace(/\//g, '')
+  var title = info.title.replace(/\//g, '_')
 
   var audio_temp_dest = path.join('/tmp', 'audio-' + tmp_name + '.mp3');
   var audio_dest = path.join(dest, title + '.mp3');


### PR DESCRIPTION
Otr fails on tracks, which contain slash ('/') in title
For example, try this: https://soundcloud.com/divine/holdon
![2015-07-16 22 06 39](https://cloud.githubusercontent.com/assets/13235519/8729849/f83b2cd6-2c06-11e5-84b4-1bc192e938a1.png)
