### PR TITLE
Adding sanitize-filename, as fs.rename() chokes on files with Slashes

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -9,6 +9,7 @@ var path = require('path');
 var request = require('request');
 var rtmpdump = require('rtmpdump');
 var url = require('url');
+var sanitize = require("sanitize-filename");
 
 function parse(str) {
   try {
@@ -33,7 +34,7 @@ function download(soundcloud_url, dest, info, callback) {
   var tmp_name = new Date().getTime();
 
   var audio_temp_dest = path.join('/tmp', 'audio-' + tmp_name + '.mp3');
-  var audio_dest = path.join(dest, info.title + '.mp3');
+  var audio_dest = path.join(dest, sanitize(info.title + '.mp3'));
   var artwork_temp_dest = path.join('/tmp', 'artwork-' + tmp_name + '.jpg');
 
   async.series([

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "id3-writer": "^1.2.2",
     "phantomjs": "Medium/phantomjs#version-2.0",
     "request": "^2.58.0",
-    "rtmpdump": "^0.1.1"
+    "rtmpdump": "^0.1.1",
+    "sanitize-filename": "^1.3.0"
   }
 }


### PR DESCRIPTION
Tracks that contain restricted characters for file paths don't get moved properly out of the `/tmp` folder. I'm guessing that `fs.rename()` is silently failing, because the log output doesn't reflect this. This also caused the cleanup temp function to fail, leaving `/tmp` full of images and mp3s.

Adding sanitize-filename ensures that `audio_dest` is valid, and can be moved.

Apologies if there is an easier way to do this, I'm super new to node. Love the utility though, it's awesome!
